### PR TITLE
Test: Explicitly use ViewHosting.expel() to remove NavigationDestination

### DIFF
--- a/LyricsPiecesTests/Acceptance Tests/MatchSongAcceptanceTests.swift
+++ b/LyricsPiecesTests/Acceptance Tests/MatchSongAcceptanceTests.swift
@@ -25,6 +25,8 @@ final class MatchSongAcceptanceTests: XCTestCase {
                 XCTAssertNoThrow(try view.actualView().inspect().find(text: "Leeland"))
                 XCTAssertNoThrow(try view.actualView().inspect().find(button: "Read Lyrics"))
                 XCTAssertNoThrow(try view.actualView().inspect().find(viewWithAccessibilityLabel: "Listen On Apple Music"))
+                
+                ViewHosting.expel()
             }
         }
     }
@@ -40,6 +42,8 @@ final class MatchSongAcceptanceTests: XCTestCase {
             try await hostedView.inspection.inspect { view in
                 XCTAssertNoThrow(try view.actualView().inspect().find(viewWithAccessibilityIdentifier: "match_error_state_view"))
                 XCTAssertNoThrow(try view.actualView().inspect().find(text: "Uh-oh, Something wrong"))
+            
+                ViewHosting.expel()
             }
         }
     }
@@ -54,6 +58,8 @@ final class MatchSongAcceptanceTests: XCTestCase {
             try await hostedView.inspection.inspect { view in
                 XCTAssertNoThrow(try view.actualView().inspect().find(viewWithAccessibilityIdentifier: "match_noMatch_state_view"))
                 XCTAssertNoThrow(try view.actualView().inspect().find(text: "No song matched"))
+                
+                ViewHosting.expel()
             }
         }
     }
@@ -65,7 +71,7 @@ final class MatchSongAcceptanceTests: XCTestCase {
         let matcher = ShazamMatcher(session: session)
         let sut = MatchView(matcher: matcher)
         // FIXME: ViewInspector doesn't support to expel NavigationStack
-//        trackForMemoryLeaks(matcher)
+        trackForMemoryLeaks(matcher)
         return sut
     }
 }

--- a/LyricsPiecesTests/Acceptance Tests/MatchSongAcceptanceTests.swift
+++ b/LyricsPiecesTests/Acceptance Tests/MatchSongAcceptanceTests.swift
@@ -27,6 +27,7 @@ final class MatchSongAcceptanceTests: XCTestCase {
                 XCTAssertNoThrow(try view.actualView().inspect().find(viewWithAccessibilityLabel: "Listen On Apple Music"))
                 
                 ViewHosting.expel()
+                ViewHosting.expel()
             }
         }
     }
@@ -44,6 +45,7 @@ final class MatchSongAcceptanceTests: XCTestCase {
                 XCTAssertNoThrow(try view.actualView().inspect().find(text: "Uh-oh, Something wrong"))
             
                 ViewHosting.expel()
+                ViewHosting.expel()
             }
         }
     }
@@ -59,6 +61,7 @@ final class MatchSongAcceptanceTests: XCTestCase {
                 XCTAssertNoThrow(try view.actualView().inspect().find(viewWithAccessibilityIdentifier: "match_noMatch_state_view"))
                 XCTAssertNoThrow(try view.actualView().inspect().find(text: "No song matched"))
                 
+                ViewHosting.expel()
                 ViewHosting.expel()
             }
         }

--- a/LyricsPiecesTests/Acceptance Tests/MatchSongAcceptanceTests.swift
+++ b/LyricsPiecesTests/Acceptance Tests/MatchSongAcceptanceTests.swift
@@ -70,7 +70,6 @@ final class MatchSongAcceptanceTests: XCTestCase {
     private func makeSUT(session: SHManagedSessionProtocol = FakeSHManagedSessionSpy()) -> MatchView {
         let matcher = ShazamMatcher(session: session)
         let sut = MatchView(matcher: matcher)
-        // FIXME: ViewInspector doesn't support to expel NavigationStack
         trackForMemoryLeaks(matcher)
         return sut
     }

--- a/LyricsPiecesTests/Acceptance Tests/MatchSongAcceptanceTests.swift
+++ b/LyricsPiecesTests/Acceptance Tests/MatchSongAcceptanceTests.swift
@@ -27,7 +27,6 @@ final class MatchSongAcceptanceTests: XCTestCase {
                 XCTAssertNoThrow(try view.actualView().inspect().find(viewWithAccessibilityLabel: "Listen On Apple Music"))
                 
                 ViewHosting.expel()
-                ViewHosting.expel()
             }
         }
     }
@@ -45,7 +44,6 @@ final class MatchSongAcceptanceTests: XCTestCase {
                 XCTAssertNoThrow(try view.actualView().inspect().find(text: "Uh-oh, Something wrong"))
             
                 ViewHosting.expel()
-                ViewHosting.expel()
             }
         }
     }
@@ -61,7 +59,6 @@ final class MatchSongAcceptanceTests: XCTestCase {
                 XCTAssertNoThrow(try view.actualView().inspect().find(viewWithAccessibilityIdentifier: "match_noMatch_state_view"))
                 XCTAssertNoThrow(try view.actualView().inspect().find(text: "No song matched"))
                 
-                ViewHosting.expel()
                 ViewHosting.expel()
             }
         }


### PR DESCRIPTION
view and let implicitly expel to remove NavigationStack